### PR TITLE
Rename `wof-opensearch-list-aliases` as `wof-opensearch-list-indices`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ cli:
 	env GOOS=$(GOOS) GOARCH=$(GOARCH) go build -mod $(GOMOD) -ldflags="$(LDFLAGS)" -o bin/wof-opensearch-put-mapping cmd/wof-opensearch-put-mapping/main.go
 	env GOOS=$(GOOS) GOARCH=$(GOARCH) go build -mod $(GOMOD) -ldflags="$(LDFLAGS)" -o bin/wof-opensearch-get-mapping cmd/wof-opensearch-get-mapping/main.go
 	env GOOS=$(GOOS) GOARCH=$(GOARCH) go build -mod $(GOMOD) -ldflags="$(LDFLAGS)" -o bin/wof-opensearch-put-settings cmd/wof-opensearch-put-settings/main.go
-	env GOOS=$(GOOS) GOARCH=$(GOARCH) go build -mod $(GOMOD) -ldflags="$(LDFLAGS)" -o bin/wof-opensearch-list-aliases cmd/wof-opensearch-list-aliases/main.go
+	env GOOS=$(GOOS) GOARCH=$(GOARCH) go build -mod $(GOMOD) -ldflags="$(LDFLAGS)" -o bin/wof-opensearch-list-indices cmd/wof-opensearch-list-indices/main.go
 	env GOOS=$(GOOS) GOARCH=$(GOARCH) go build -mod $(GOMOD) -ldflags="$(LDFLAGS)" -o bin/wof-opensearch-indices-stats cmd/wof-opensearch-indices-stats/main.go
 
 doc:

--- a/README.md
+++ b/README.md
@@ -89,12 +89,12 @@ $> ./bin/wof-opensearch-index \
 
 TBW. Have a look at [writer/writer_opensearch2.go](writer/writer_opensearch2.go) and [whosonfirst/go-whosonfirst-iterwriter](https://github.com/whosonfirst/go-whosonfirst-iterwriter) for the time being.
 
-### wof-opensearch-list-aliases
+### wof-opensearch-list-indices
 
-List all the aliases for an OpenSearch instance.
+List all the indices for an OpenSearch instance.
 
 ```
-$> ./bin/wof-opensearch-list-aliases \
+$> ./bin/wof-opensearch-list-indices \
 	-opensearch-aws-credentials-uri 'aws://{REGION}?credentials=iam:' \
 	-opensearch-endpoint https://{OPENSEARCH_DOMAIN}.{REGION}.es.amazonaws.com \
 ```


### PR DESCRIPTION
* Rename `wof-opensearch-list-aliases` as `wof-opensearch-list-indices` (and make it work using newer /v4 APIs)
* Update vendor deps